### PR TITLE
better support for the default Nim allocator

### DIFF
--- a/actors/pool.nim
+++ b/actors/pool.nim
@@ -404,7 +404,7 @@ proc hatchAux*(pool: ptr Pool, c: sink ActorCont, parent=Actor(), linked=false):
   assert not isNil(c)
   #assertIsolated(c)
 
-  let a = create(ActorObject)
+  let a = createShared(ActorObject)
   a.pid = pool.actorPidCounter.fetchAdd(1)
   a.pool = pool
   a.rc.store(0)


### PR DESCRIPTION
Each thread has its own heap, and then there's also the shared heap. An `ActorObject` was created on the thread-local heap (`create`), but deallocated from the shared one (`deallocShared`).

Using `createShared` for allocating the actor makes it work for pre Nim 2.0. At the moment, an allocator bug with Nim 2.0 makes it impossible to allocate and deallocate an `ActorObject` on different threads.