### PR TITLE
support disabling valgrind

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ for all the actors to terminate and clean up all the resources used.
 
 
 
+### Valgrind
+
+To make the library aware of being run with helgrind, the program needs to be
+built with `-d:usesValgrind`, otherwise false positives could be reported.
+
+
 ### More to come
 
 Sure.

--- a/actors/pool.nim
+++ b/actors/pool.nim
@@ -6,8 +6,6 @@ import isisolated
 import mallinfo
 import valgrind
 
-{.emit:"#include <valgrind/helgrind.h>".}
-
 type
 
   Pool* = object

--- a/actors/valgrind.nim
+++ b/actors/valgrind.nim
@@ -1,20 +1,29 @@
 
+const
+  usesValgrind {.booldefine.} = false
+
 {.emit:"#include <valgrind/helgrind.h>".}
 
 template valgrind_annotate_happens_before*(x) =
   block:
     let y {.exportc,inject.} = x
-    {.emit:"ANNOTATE_HAPPENS_BEFORE(y);".}
+    when usesValgrind:
+      {.emit:"ANNOTATE_HAPPENS_BEFORE(y);".}
 
 template valgrind_annotate_happens_after*(x) =
   block:
     let y {.exportc,inject.} = x
-    {.emit:"ANNOTATE_HAPPENS_AFTER(y);".}
+    when usesValgrind:
+      {.emit:"ANNOTATE_HAPPENS_AFTER(y);".}
 
 template valgrind_annotate_happens_before_forget_all*(x) =
   block:
     let y {.exportc,inject.} = x
-    {.emit:"ANNOTATE_HAPPENS_BEFORE_FORGET_ALL(y);".}
+    when usesValgrind:
+      {.emit:"ANNOTATE_HAPPENS_BEFORE_FORGET_ALL(y);".}
 
 proc running_on_valgrind*(): bool =
-  {.emit: "result = RUNNING_ON_VALGRIND;".}
+  when usesValgrind:
+    {.emit: "result = RUNNING_ON_VALGRIND;".}
+  else:
+    false

--- a/tests/nim.cfg
+++ b/tests/nim.cfg
@@ -1,0 +1,1 @@
+--define:usesValgrind


### PR DESCRIPTION
The Valgrind integration is now disabled by default, requiring one to define the conditional `usesValgrind` symbol for enabling it.

So that conditional compilation of the Valgrind integration works, the FFI is changed to use `.importc` procedures and constants instead of `.emit`, also making the code rely less on Nim code generator implementation details.

Fixes #5. 